### PR TITLE
docs: add MANUAL.org

### DIFF
--- a/MANUAL.org
+++ b/MANUAL.org
@@ -1,0 +1,493 @@
+#+TITLE: My Emacs 使用说明
+#+AUTHOR: alfa
+#+OPTIONS: toc:2 num:nil ^:nil
+#+STARTUP: overview
+
+* 总览
+
+这是一份针对 ~~/.emacs.d/~ 当前配置的速查手册。底层是 Emacs 30 + 内置
+~package.el~ + ~use-package~,语言主攻 C / C++ / Go / Rust,Org-mode 做笔记。
+
+打开本手册的快捷键: ~C-c m~ 。
+
+仓库地址: ~https://github.com/ki827/.emacs.d~ 。新机器克隆后第一次启动会自动从
+MELPA 装包,tree-sitter grammar 也会自动编译,不需手动操作。
+
+* 修饰键映射(macOS · HHKB)
+
+| 物理键        | 在 Emacs 里 | 写作 |
+|---------------+-------------+------|
+| ⌘ Cmd(左/右)  | Control     | C-   |
+| ⌥ Opt(左/右)  | Meta        | M-   |
+| Control(A 旁) | Control     | C-   |
+
+阅读下面的快捷键时,凡 ~C-x~ 一律是 *Cmd-X*, ~M-x~ 是 *Opt-X* 。
+
+* 启动与重载
+
+| 操作             | 命令 / 键位                        |
+|------------------+------------------------------------|
+| 启动后看耗时     | 状态栏会 echo "Emacs ready in ..." |
+| 重新加载某个模块 | ~M-x load-file~ → 选 .el           |
+| 完全重启         | ~C-x C-c~ 退出后重开               |
+
+首次启动时会从 MELPA 自动安装第三方包,需要联网,通常 1–2 分钟。
+
+* 目录结构
+
+#+begin_src text
+~/.emacs.d/
+├── early-init.el                  # GC、原生编译、UI 早期抑制
+├── init.el                        # 包系统 + 模块加载 + 全局便利绑定
+├── MANUAL.org                     # 本文件
+├── .gitignore                     # 排除 elpa / 状态文件
+├── lisp/
+│   ├── core-ui.el                 # 主题、行号、字体(cnfonts)
+│   ├── core-editor.el             # 备份、savehist、recentf、dired、修饰键
+│   ├── core-completion.el         # vertico / consult / corfu / cape ...
+│   ├── core-project.el            # project.el / magit / envrc
+│   ├── core-prog.el               # tree-sitter / eglot / apheleia / dape
+│   ├── lang-c.el                  # C / C++ 专用
+│   ├── lang-go.el                 # Go 专用
+│   ├── lang-rust.el               # Rust 专用
+│   └── lang-org.el                # Org-mode + CJK 软换行
+├── elpa/                          # 第三方包(自动管理,git 忽略)
+├── eln-cache/ tree-sitter/        # 原生编译 + tree-sitter 缓存(忽略)
+├── cnfonts/                       # 字号 profile(忽略)
+├── auto-save/ backups/            # 编辑状态(忽略)
+└── custom.el                      # M-x customize 写入(忽略)
+#+end_src
+
+* 文件 / Buffer / 窗口
+
+| 操作                | 键位                  |
+|---------------------+-----------------------|
+| 打开文件            | ~C-x C-f~             |
+| 保存当前文件        | ~C-x C-s~             |
+| 切 buffer(模糊搜索) | ~C-x b~               |
+| 最近文件            | ~C-x C-r~             |
+| 关闭 buffer         | ~C-x k~               |
+| 当前窗口最大化      | ~C-x 1~               |
+| 横向分屏            | ~C-x 2~               |
+| 纵向分屏            | ~C-x 3~               |
+| 关闭当前窗口        | ~C-x 0~               |
+| 切到下一个窗口      | ~C-x o~               |
+| 取消任何操作        | ~C-g~                 |
+| 撤销                | ~C-/~                 |
+| 标记/选区起点       | ~C-'~                 |
+| 复制 / 剪切 / 粘贴  | ~M-w~ / ~C-w~ / ~C-y~ |
+
+注:Cmd-C / Cmd-V 在 Emacs 里被映射成 C-c / C-v(因为 Cmd 已映射为 Control),所以
+*macOS 风格的复制粘贴在 Emacs 内不可用* 。请用上表的键。
+
+注:Emacs 默认 ~set-mark-command~ 是 ~C-SPC~,但在 macOS 上 ~Ctrl-Space~ 通常被
+系统级输入法切换占用,Emacs 收不到该事件;因此本配置把 ~set-mark-command~ 重新
+绑定到 ~C-'~。用法:落点 → 移光标到选区终点 → 任意 ~M-w~ / ~C-w~ / 格式化命令
+作用于该选区; ~C-g~ 取消选中。
+
+* Minibuffer 补全(Vertico + Consult + Embark)
+
+输入命令、查文件、跳行号——所有要从一堆候选里选一个的场景都走 minibuffer。
+
+| 操作                      | 键位          |
+|---------------------------+---------------|
+| 执行命令                  | ~M-x~         |
+| 候选下移 / 上移           | ~C-n~ / ~C-p~ |
+| 选中并执行                | ~RET~         |
+| 取消                      | ~C-g~         |
+| 在当前 buffer 增量查找    | ~C-s~         |
+| 跨项目 ripgrep            | ~M-s r~       |
+| 在项目里按文件名 find     | ~M-s f~       |
+| 跳到行号                  | ~M-g g~       |
+| 跳到 imenu(函数 / 类目录) | ~M-g i~       |
+| 杀死环 / 历史粘贴         | ~M-y~         |
+
+** Embark — 对当前候选执行操作
+
+| 操作                                    | 键位    |
+|-----------------------------------------+---------|
+| 弹出"对当前候选可以做什么"操作菜单      | ~C-.~   |
+| 默认动作(对光标处的智能动作,如跳转定义) | ~M-.~   |
+| 列出当前所有可用快捷键                  | ~C-h B~ |
+
+例:在 minibuffer 里搜文件时按 ~C-.~ → 选 "rename" / "delete" / "copy path" 等。
+
+** Orderless 输入语法
+
+candidate 框里多个词用空格分隔即可,顺序不限。例:
+- ~M-x~ 后输入 ~rep buf~ 能匹配到 ~replace-regexp~ 也能匹配到 ~revert-buffer~。
+- 前缀 ~!~ 表示排除,~^~ 表示开头,~$~ 表示结尾。
+
+* Buffer 内补全(Corfu + Cape)
+
+写代码时光标右边弹出的小窗。
+
+| 操作               | 键位                  |
+|--------------------+-----------------------|
+| 触发               | 自动(键入 2 字符)     |
+| 上下选             | ~C-n~ / ~C-p~         |
+| 选中并插入         | ~RET~ 或 ~TAB~        |
+| 取消               | ~C-g~ 或 ~ESC~        |
+| 显示候选的额外信息 | 自动(corfu-popupinfo) |
+
+按 ~TAB~ 在词尾位置直接触发补全(~tab-always-indent = complete~)。
+
+* 项目(project.el — 内置)
+
+任何含 ~.git~ 的目录自动识别为 project。
+
+| 操作              | 键位      |
+|-------------------+-----------|
+| 项目快捷键前缀    | ~C-x p~   |
+| 项目内查找文件    | ~C-x p f~ |
+| 项目内 grep       | ~C-x p g~ |
+| 切到另一个项目    | ~C-x p p~ |
+| 项目里某个 buffer | ~C-x p b~ |
+| 在项目里 shell    | ~C-x p s~ |
+| 编译              | ~C-x p c~ |
+
+* Git(Magit)
+
+| 操作           | 键位      |
+|----------------+-----------|
+| Magit 状态面板 | ~C-x g~   |
+| Magit 命令分发 | ~C-x M-g~ |
+
+进入 Magit 后: ~s~ 暂存, ~u~ 取消暂存, ~c c~ 提交, ~P p~ push, ~F p~ pull,
+~l l~ 看历史, ~b b~ 切分支, ~?~ 弹出帮助。
+
+* LSP(Eglot)
+
+打开 C/C++/Go/Rust 文件时自动连接对应 LSP(clangd / gopls / rust-analyzer)。
+
+| 操作                | 键位                                      |
+|---------------------+-------------------------------------------|
+| 跳转到定义          | ~M-.~(经 Embark)/ ~xref-find-definitions~ |
+| 返回                | ~M-,~                                     |
+| 查所有引用          | ~M-?~                                     |
+| 重命名              | ~C-c l r~                                 |
+| 代码动作(quick-fix) | ~C-c l a~                                 |
+| 格式化(整文件)      | ~C-c l f~                                 |
+| 文档悬浮            | ~C-c l h~ 或停留                          |
+| 重启 LSP            | ~M-x eglot-reconnect~                     |
+
+* 诊断(Flymake)
+
+LSP 报的错/警告由 Flymake 显示在左 fringe。
+
+| 操作           | 键位                                  |
+|----------------+---------------------------------------|
+| 下一个错误     | ~M-n~                                 |
+| 上一个错误     | ~M-p~                                 |
+| 看所有诊断列表 | ~M-x flymake-show-buffer-diagnostics~ |
+
+* 自动格式化(Apheleia)
+
+保存时异步格式化(*不阻塞*, *不破坏 undo*):
+- C/C++ → ~clang-format~
+- Go → ~goimports~
+- Rust → ~rustfmt~
+
+如不想全局格式化,某 buffer 临时关:~M-x apheleia-mode~。
+
+* 调试(Dape)
+
+支持 lldb(C/C++/Rust)和 delve(Go)。
+
+| 操作     | 命令                         |
+|----------+------------------------------|
+| 启动调试 | ~M-x dape~                   |
+| 加断点   | ~M-x dape-breakpoint-toggle~ |
+| 单步     | 调试 transient 里 ~n~        |
+| 进入函数 | 调试 transient 里 ~i~        |
+| 跳出     | 调试 transient 里 ~o~        |
+| 继续     | 调试 transient 里 ~c~        |
+
+断点会自动持久化到  ~~/.emacs.d/var/dape-breakpoints~ 。
+
+* 模板片段(Tempel)
+
+| 操作                   | 键位          |
+|------------------------+---------------|
+| 在光标处补全模板名     | ~M-+~         |
+| 选一个已知模板插入     | ~M-*~         |
+| 模板内字段间跳转       | ~M-{~ / ~M-}~ |
+
+模板库来自 ~tempel-collection~,自带常见 prog-mode 片段。自定义模板写在
+~~/.emacs.d/templates~ 文件里。
+
+* 行号 / 主题 / 字体
+
+** 行号
+
+~prog-mode~ 与 ~org-mode~ 默认显示绝对行号。临时关:~M-x display-line-numbers-mode~ 。
+
+** 主题
+
+| 操作          | 命令                                        |
+|---------------+---------------------------------------------|
+| 切任意主题    | ~M-x load-theme~                            |
+| ef 主题快速切 | ~M-x ef-themes-select~ / ~ef-themes-toggle~ |
+
+当前主题: ~ef-elea-light~ 。
+
+** 字号(cnfonts 管理)
+
+字体大小由 ~cnfonts~ 接管——它为每个字号档位预先匹配好"ASCII : CJK = 1 : 2"的精确尺寸对,
+切档位时中英文表格自动保持视觉对齐。
+
+| 操作                  | 命令                                            |
+|-----------------------+-------------------------------------------------|
+| 升一档字号            | ~M-x cnfonts-increase-fontsize~                 |
+| 降一档字号            | ~M-x cnfonts-decrease-fontsize~                 |
+| 重置为默认字号        | ~M-x cnfonts-reset-fontsize~                    |
+| 编辑当前档位的尺寸表  | ~M-x cnfonts-edit-profile~                      |
+| 在档位间挑一个        | ~M-x cnfonts-set-font-with-saved-fontsize~      |
+
+当前默认字号:18 pt(在 ~lisp/core-ui.el~ 里 ~cnfonts-default-fontsize~ 设置)。
+所选档位会持久化到 ~~/.emacs.d/cnfonts/~,下次启动直接生效,不必每台机器再调一次。
+
+字体优先选择列表(在 ~core-ui.el~ 的 ~cnfonts-personal-fontnames~):
+- ASCII:JetBrains Mono → Fira Code → SF Mono → Menlo
+- CJK:Sarasa Mono SC → PingFang SC → Hiragino Sans GB → STHeiti
+
+* C / C++
+
+- ~.h~ 走 ~c-or-c++-ts-mode~(自动判 C/C++)
+- ~.c~ → ~c-ts-mode~, ~.cpp~/~.cc~/~.cxx~/~.hpp~ → ~c++-ts-mode~
+- 缩进 4 空格,Linux 风格
+- LSP:clangd,启用 ~--clang-tidy~ + 后台索引
+- CMake 文件用 ~cmake-ts-mode~
+- *电子缩进特例*: ~:~ 已从 ~electric-indent-chars~ 移除,避免输入 ~std:~ 时被
+  parser 当成 label 而瞬间跳到列 0(等输入第二个 ~:~ 才回正)。代价是 ~switch~
+  的 ~case ...:~ 和 ~goto~ label 不会自动 dedent——这两个用得少,需要时手动 ~TAB~ 即可。
+
+最佳实践:在项目根放一个 ~compile_commands.json~(CMake 用 ~-DCMAKE_EXPORT_COMPILE_COMMANDS=ON~ 生成,Bazel 用 ~bazel-compdb~,纯 Make 用 ~bear -- make~)。clangd 会自动找到。
+
+* Go
+
+- 文件类型:~.go~ → ~go-ts-mode~,~go.mod~ → ~go-mod-ts-mode~
+- LSP:gopls,启用 ~staticcheck~ + ~gofumpt~ + 全套 inlay hints
+- 保存时自动 goimports
+
+* Rust
+
+- ~.rs~ → ~rust-ts-mode~
+- LSP:rust-analyzer, ~cargo check~ 替换为 ~clippy~ ,启用 inlay hints
+- 保存时自动 ~rustfmt~
+- ~rust-ts-mode~ 自带的 ~rust-ts-flymake~ 后端已禁用,避免与 eglot 的 LSP 诊断
+  竞态(过去会偶发 ~Can't find state for rust-ts-flymake in flymake--state~ )。
+  所有诊断由 rust-analyzer 经 eglot 提供。
+
+* 包管理(package.el)
+
+新装一个包(临时):
+#+begin_src
+M-x package-install RET <pkg> RET
+#+end_src
+
+把它写进配置(永久):在合适的模块文件里加一段 ~use-package~,例如:
+#+begin_src elisp
+(use-package some-pkg
+  :bind (("C-c x" . some-pkg-command))
+  :init (setq some-pkg-foo t)
+  :config (some-pkg-mode 1))
+#+end_src
+~use-package-always-ensure~ 已开启,无需手动 ~:ensure t~。
+
+升级所有包: ~M-x package-upgrade-all~ 。
+列出已装包: ~M-x package-list-packages~ 。
+
+* Tree-sitter 语法
+
+C / C++ / Go / Rust 的 grammar 已预装。新增其它语言:
+1. 在 ~lisp/core-prog.el~ 的 ~treesit-language-source-alist~ 加一项;
+2. ~M-x treesit-install-language-grammar~ 选语言。
+
+* 故障排查 / FAQ
+
+** 启动很慢 / 报包错
+~M-x package-refresh-contents~,然后重启。
+
+** LSP 没起来
+- 确认对应工具在 ~PATH~ 中:终端跑 ~which clangd~ / ~which gopls~ / ~which rust-analyzer~ 。
+- 在 Emacs 里 ~M-x getenv RET PATH RET~ 看是否一致。GUI Emacs 由 ~exec-path-from-shell~ 自动同步。
+- ~M-x eglot~ 手动启动并看 ~*EGLOT events*~ buffer。
+
+** 哪些键已经被绑了
+- 按某个前缀停一会儿,which-key 自动列出后续可选(如按 ~C-x p~ 等 0.5 秒)。
+- 全局看: ~M-x describe-keymap RET global-map RET~ 。
+- 在 minibuffer 里: ~C-h B~ 列 Embark 视角的可用动作。
+
+** 想看某个键绑了什么
+~C-h k~ 然后按那个键。
+
+** 想看某个命令绑在哪
+~C-h w~ 后输入命令名。
+
+** 修改没生效
+- 改了模块文件 → ~M-x load-file~ 重新加载该模块,或重启。
+- 改了主题 → ~M-x disable-theme~ 关旧的, ~M-x load-theme~ 加新的。
+
+** 想清掉一个错乱的状态
+- 单 buffer: ~M-x revert-buffer~ 。
+- 全局: ~M-x emacs-init-time~ 看是否健康;实在不行重启。
+
+** dired 提示 ~ls does not support --dired -N~
+
+macOS 自带 BSD ~ls~ 不支持 GNU 的 ~--dired~ 选项,我们已经做了自动适配:
+- 检测到 ~gls~(GNU coreutils)就用它,获得完整 dired 功能;
+- 没有就退化成普通 ~ls~,警告消失但 dired 略简陋。
+
+想要全功能版:
+
+#+begin_src sh
+brew install coreutils
+#+end_src
+
+下次启动 Emacs 自动切换。
+
+** 看到红/蓝波浪线但没有错误文字
+
+Flymake 用波浪线标错位置(红=error,蓝=info),错误内容默认只在以下场景显示:
+- 光标停在波浪线上 → echo area(屏幕底部)显示
+- ~M-n~ / ~M-p~ 跳到下/上一个错误 → 同时 echo
+- ~M-x flymake-show-buffer-diagnostics~ → 列出全部
+
+* 升级配置
+
+修改后运行批处理校验,确认没有错误:
+#+begin_src sh
+emacs --batch -l ~/.emacs.d/init.el --eval '(message "OK")'
+#+end_src
+
+* Org-mode
+
+** 启用的增强
+
+纯 Org 内置,不引入第三方包。
+
+- ~visual-line-mode~:软换行,不在文件里写死换行符
+- ~word-wrap-by-category t~:让软换行能在中文之间正确断行(中文无空格,默认会断行不准)
+- ~org-startup-indented~:标题层级缩进显示
+- ~org-pretty-entities~: ~\alpha~ 显示成 α, ~\to~ 显示成 →
+- 源码块原生语法高亮、TAB 缩进、保留缩进
+- TODO 流转 + 完成时间戳
+
+** TODO 关键字流转
+
+#+begin_src text
+TODO → DOING → WAIT → DONE / CANCELED
+#+end_src
+
+完成时自动记录时间戳。在标题处按 ~C-c C-t~ 切换状态。
+
+** 标题与结构
+
+| 操作               | 键位                  |
+|--------------------+-----------------------|
+| 折叠 / 展开当前节  | ~TAB~                 |
+| 全文折叠循环       | ~S-TAB~               |
+| 上一 / 下一标题    | ~C-c C-p~ / ~C-c C-n~ |
+| 同级上 / 下移标题  | ~M-S-↑~ / ~M-S-↓~     |
+| 升级 / 降级标题    | ~M-S-←~ / ~M-S-→~     |
+| 在当前位置新建标题 | ~M-RET~               |
+| 切换 TODO          | ~C-c C-t~             |
+| 加 / 改标签        | ~C-c C-q~             |
+| 时间戳             | ~C-c .~               |
+
+** 链接与导航
+
+| 操作                | 键位        |
+|---------------------+-------------|
+| 跟随链接 / 进入表格 | ~C-c C-o~   |
+| 在标题之间跳转      | ~C-c C-j~   |
+| 插入链接            | ~C-c C-l~   |
+
+** 列表
+
+| 操作          | 键位                   |
+|---------------+------------------------|
+| 新条目        | ~M-RET~                |
+| 上 / 下移条目 | ~M-S-↑~ / ~M-S-↓~      |
+| 升 / 降级     | ~M-S-←~ / ~M-S-→~      |
+| 切换复选框    | ~C-c C-c~(在 ~[ ]~ 上) |
+
+** 表格
+
+| 操作            | 键位                    |
+|-----------------+-------------------------|
+| 下一格 / 上一格 | ~TAB~ / ~S-TAB~         |
+| 对齐            | ~C-c C-c~               |
+| 加行 / 删行     | ~M-S-↓~ / ~M-S-↑~(整行) |
+| 加列 / 删列     | ~M-S-→~ / ~M-S-←~(整列) |
+| 计算公式        | ~C-c =~                 |
+
+*Org 表格 CJK 对齐*: Org 内置 ~org-table-align~ 按 ~string-width~ 计算,中文字符宽度=2、英文=1。要在屏幕上真的看到对齐,字体必须是 *真正的 1:2 等宽 CJK 字体* ——Sarasa Mono SC 是最佳选择(见下面"中文 / CJK 支持")。Hiragino Sans GB 这类系统字体不是 1:2 等宽,即便 Org 算得对,看着也不齐。
+
+** 源代码块
+
+#+begin_src org
+#+begin_src elisp
+(message "hello")
+#+end_src
+#+end_src
+
+| 操作                       | 键位      |
+|----------------------------+-----------|
+| 在专用 buffer 里编辑代码块 | ~C-c '~   |
+| 执行代码块                 | ~C-c C-c~ |
+| 退出 src 编辑回到 org      | ~C-c '~   |
+
+src 块支持原生语法高亮、TAB 缩进、保留缩进。
+
+* 中文 / CJK 支持
+
+** 字体
+
+字体管理由 ~cnfonts~ 接管,见上面"行号 / 主题 / 字体"章节。它做两件事:
+1. 在 ASCII 优先列表里挑第一个可用的 ASCII 字体,在 CJK 优先列表里挑第一个可用的 CJK 字体;
+2. 按选定档位为这两个字体配一对精确尺寸,保证 1 个 CJK 字符 = 2 个 ASCII 字符的视觉宽度。
+
+推荐字体: *Sarasa Mono SC* ——基于 Iosevka(英文)+ 思源黑体(中文),内部就是
+设计成 1:2 等宽。安装:
+
+#+begin_src sh
+brew install --cask font-sarasa-gothic
+#+end_src
+
+LXGW WenKai(书法体阅读字体)备选:
+
+#+begin_src sh
+brew install --cask font-lxgw-wenkai-mono
+#+end_src
+
+装完重启 Emacs,cnfonts 会自动选用。
+
+** 中文换行
+
+~visual-line-mode~ + ~word-wrap-by-category t~ 已开,中文段落软换行符合预期(不会切到中文字符正中间,标点也会留在行尾而不是换行后开头)。
+
+** 中文输入
+
+不在 Emacs 内配置,使用 macOS 系统输入法即可。注意我们把 Cmd 映射成 Control 了,
+所以默认 ~set-mark~ 的 ~C-SPC~ 与系统级 Ctrl-Space 输入法切换冲突——本配置已把
+~set-mark-command~ 改绑到 ~C-'~,见"文件 / Buffer / 窗口"章节。
+
+*建议:* macOS 设置 → 键盘 → 输入法 → 用 Caps Lock 切换"ABC / 中文",彻底
+跟 Ctrl-Space 解耦。
+
+** Org 中文标点
+
+中英文混排建议用 *半角空格* 隔开数字 / 英文 / 中文,看着更专业。这是排版习惯,不是 Emacs 的事。
+
+* 常用 Org-mode 速查
+
+| 操作              | 键位                  |
+|-------------------+-----------------------|
+| 折叠 / 展开       | ~TAB~                 |
+| 全部折叠 / 展开   | ~S-TAB~               |
+| 跳到上一/下一标题 | ~C-c C-p~ / ~C-c C-n~ |
+| 跟随链接 / 表格   | ~C-c C-o~             |
+| 切换 TODO         | ~C-c C-t~             |
+| 退出 org buffer   | ~C-x k~               |

--- a/README.org
+++ b/README.org
@@ -10,7 +10,7 @@
 
 打开本手册的快捷键： ~C-c m~ 。
 
-仓库地址：~https://github.com/ki827/.emacs.d~ 。新机器克隆后第一次启动会自动从
+仓库地址： ~https://github.com/ki827/.emacs.d~ 。新机器克隆后第一次启动会自动从
 MELPA 装包，tree-sitter grammar 也会自动编译，不需手动操作。
 
 * 修饰键映射(macOS · HHKB)


### PR DESCRIPTION
## Summary
- Adds the previously untracked `MANUAL.org` to the repository.

## Test plan
- [ ] Confirm `MANUAL.org` renders correctly on the PR file view.
- [ ] Verify it does not duplicate or conflict with the existing `README.org`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)