### PR TITLE
refactor(ui): drop cnfonts for Ubuntu Mono; rebind set-mark to C-;

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ backups/
 cnfonts/
 custom.el
 dape-breakpoints
+exec-path-cache.el
 history
 places
 projects

--- a/README.org
+++ b/README.org
@@ -42,7 +42,7 @@ MELPA 装包，C / C++ / Go / Rust 的 tree-sitter grammar 也会自动编译，
 ├── README.org                     # 本文件,GitHub 渲染入口
 ├── .gitignore                     # 排除 elpa / 状态文件
 ├── lisp/
-│   ├── core-ui.el                 # 主题、行号、字体(cnfonts)
+│   ├── core-ui.el                 # 主题、行号、字体
 │   ├── core-editor.el             # 备份、savehist、recentf、dired、修饰键
 │   ├── core-completion.el         # vertico / consult / corfu / cape ...
 │   ├── core-project.el            # project.el / magit / envrc
@@ -54,7 +54,6 @@ MELPA 装包，C / C++ / Go / Rust 的 tree-sitter grammar 也会自动编译，
 │   └── lang-markdown.el           # Markdown / GFM
 ├── elpa/                          # 第三方包(自动管理,git 忽略)
 ├── eln-cache/ tree-sitter/        # 原生编译 + tree-sitter 缓存(忽略)
-├── cnfonts/                       # 字号 profile(忽略)
 ├── auto-save/ backups/            # 编辑状态(忽略)
 └── custom.el                      # M-x customize 写入(忽略)
 #+end_src
@@ -232,25 +231,20 @@ LSP 报的错/警告由 Flymake 显示在左 fringe。
 
 当前主题： ~ef-elea-light~ 。
 
-** 字号（cnfonts 管理）
+** 字体 / 字号
 
-字体大小由 ~cnfonts~ 接管——它为每个字号档位预先匹配好"ASCII : CJK = 1 : 2"的精确尺寸对，
-切档位时中英文表格自动保持视觉对齐。
+直接用 macOS 自带的 *Monaco* ，CJK 走系统默认回退（PingFang SC 等），
+不显式接 fontset。
 
-| 操作                  | 命令                                            |
-|-----------------------+-------------------------------------------------|
-| 升一档字号            | ~M-x cnfonts-increase-fontsize~                 |
-| 降一档字号            | ~M-x cnfonts-decrease-fontsize~                 |
-| 重置为默认字号        | ~M-x cnfonts-reset-fontsize~                    |
-| 编辑当前档位的尺寸表  | ~M-x cnfonts-edit-profile~                      |
-| 在档位间挑一个        | ~M-x cnfonts-set-font-with-saved-fontsize~      |
+#+begin_src elisp
+(set-face-attribute 'default nil :family "Monaco" :height 180)
+#+end_src
 
-当前默认字号：18 pt（在 ~lisp/core-ui.el~ 里 ~cnfonts-default-fontsize~ 设置）。
-所选档位会持久化到 =~/.emacs.d/cnfonts/= ，下次启动直接生效，不必每台机器再调一次。
+~:height~ 单位是 1/10 pt，180 = 18pt。改这一行就是改全局字号。临时缩放用
+~C-x C-+~ / ~C-x C--~ （ ~text-scale-adjust~ ）。
 
-字体优先选择列表（在 ~core-ui.el~ 的 ~cnfonts-personal-fontnames~ ）:
-- ASCII:JetBrains Mono → Fira Code → SF Mono → Menlo
-- CJK:Sarasa Mono SC → PingFang SC → Hiragino Sans GB → STHeiti
+*待办* ：PingFang SC 不是与 Monaco 1:2 等宽的 CJK 字体，所以 Org / Markdown
+表格中英混排不会自动对齐。后续再单独研究方案。
 
 * C / C++
 
@@ -456,7 +450,7 @@ TODO → DOING → WAIT → DONE / CANCELED
 | 加列 / 删列     | ~M-S-→~ / ~M-S-←~ (整列) |
 | 计算公式        | ~C-c =~                 |
 
-*Org 表格 CJK 对齐* ：Org 内置 ~org-table-align~ 按 ~string-width~ 计算，中文字符宽度 =2、英文= 1。要在屏幕上真的看到对齐，字体必须是 *真正的 1:2 等宽 CJK 字体* ——Sarasa Mono SC 是最佳选择（见下面"中文 / CJK 支持"）。Hiragino Sans GB 这类系统字体不是 1:2 等宽，即便 Org 算得对，看着也不齐。
+*Org 表格 CJK 对齐* ：Org 内置 ~org-table-align~ 按 ~string-width~ 计算，中文字符宽度 =2、英文= 1。要在屏幕上真的看到对齐，字体必须是 *真正的 1:2 等宽 CJK 字体* 。当前用 Monaco + 系统 PingFang 不满足这一点，混排表格不会对齐——后续再研究方案。
 
 ** 源代码块
 
@@ -478,24 +472,11 @@ src 块支持原生语法高亮、TAB 缩进、保留缩进。
 
 ** 字体
 
-字体管理由 ~cnfonts~ 接管，见上面"行号 / 主题 / 字体"章节。它做两件事：
-1. 在 ASCII 优先列表里挑第一个可用的 ASCII 字体，在 CJK 优先列表里挑第一个可用的 CJK 字体；
-2. 按选定档位为这两个字体配一对精确尺寸，保证 1 个 CJK 字符 = 2 个 ASCII 字符的视觉宽度。
+走 macOS 默认：Latin 用系统 Monaco，CJK 由系统字体回退接管（macOS
+内置已经装了 PingFang SC / Hiragino Sans GB / STHeiti 等，按 fontset
+顺序自动挑）。无需额外安装。
 
-推荐字体： *Sarasa Mono SC* ——基于 Iosevka(英文)+ 思源黑体（中文），内部就是
-设计成 1:2 等宽。安装：
-
-#+begin_src sh
-brew install --cask font-sarasa-gothic
-#+end_src
-
-LXGW WenKai（书法体阅读字体）备选：
-
-#+begin_src sh
-brew install --cask font-lxgw-wenkai-mono
-#+end_src
-
-装完重启 Emacs，cnfonts 会自动选用。
+具体见上面"字体 / 字号"章节。
 
 ** 中文换行
 

--- a/early-init.el
+++ b/early-init.el
@@ -6,10 +6,6 @@
 
 (setq inhibit-default-init t)
 
-;; Allow the frame to grow/shrink in pixels when the font (or font size)
-;; changes — required for cnfonts size switches to keep column/row count.
-(setq frame-inhibit-implied-resize nil)
-
 ;; Suppress chrome before the first frame paints to avoid flash.
 (push '(menu-bar-lines . 0)   default-frame-alist)
 (push '(tool-bar-lines . 0)   default-frame-alist)

--- a/init.el
+++ b/init.el
@@ -13,7 +13,9 @@
 ;; usually done automatically before init.el runs, but `emacs --batch'
 ;; skips it, and calling it twice is harmless.
 (package-initialize)
-(unless package-archive-contents
+;; Skip the network refresh under `emacs --batch'; in interactive
+;; sessions a missing archive cache happens at most on first run.
+(when (and (not package-archive-contents) (not noninteractive))
   (package-refresh-contents))
 
 ;;; use-package (built-in since Emacs 29)

--- a/lisp/core-completion.el
+++ b/lisp/core-completion.el
@@ -67,8 +67,15 @@
 
 (use-package cape
   :init
-  (add-to-list 'completion-at-point-functions #'cape-file)
-  (add-to-list 'completion-at-point-functions #'cape-dabbrev))
+  ;; Attach as buffer-local fallbacks (after LSP and tempel which
+  ;; prepend themselves) instead of polluting the global capf list,
+  ;; which would otherwise reach into eshell, minibuffer, etc.
+  (defun my/cape-setup-capf ()
+    (setq-local completion-at-point-functions
+                (append completion-at-point-functions
+                        (list #'cape-dabbrev #'cape-file))))
+  (add-hook 'prog-mode-hook #'my/cape-setup-capf)
+  (add-hook 'text-mode-hook #'my/cape-setup-capf))
 
 (provide 'core-completion)
 ;;; core-completion.el ends here

--- a/lisp/core-editor.el
+++ b/lisp/core-editor.el
@@ -55,9 +55,9 @@
 
 ;; Alternate `set-mark' binding. The default C-SPC is commonly captured
 ;; by the OS-level input-method switcher on macOS, leaving Emacs unable
-;; to start a region selection.  C-' is free in default Emacs and easy
+;; to start a region selection.  C-; is free in default Emacs and easy
 ;; to reach on HHKB.
-(global-set-key (kbd "C-'") #'set-mark-command)
+(global-set-key (kbd "C-;") #'set-mark-command)
 
 ;; macOS modifier mapping for HHKB layout: Cmd -> Control, Opt -> Meta.
 ;; Both left and right variants are set so external keyboards behave the

--- a/lisp/core-editor.el
+++ b/lisp/core-editor.el
@@ -8,7 +8,7 @@
  require-final-newline t
  sentence-end-double-space nil)
 
-(let ((backups-dir   (expand-file-name "backups"   user-emacs-directory))
+(let ((backups-dir   (expand-file-name "backups/"   user-emacs-directory))
       (auto-save-dir (expand-file-name "auto-save/" user-emacs-directory)))
   (dolist (d (list backups-dir auto-save-dir))
     (unless (file-directory-p d) (make-directory d t)))
@@ -125,9 +125,12 @@
 (use-package recentf
   :ensure nil
   :init
+  ;; Patterns are regexps; anchor `\.cache' and `elpa' so they don't
+  ;; match unrelated paths that happen to contain those substrings.
   (setq recentf-max-saved-items 200
         recentf-max-menu-items 25
-        recentf-exclude '("/tmp/" "/ssh:" "/var/folders/" ".cache" "elpa"))
+        recentf-exclude '("/tmp/" "/ssh:" "/var/folders/"
+                          "/\\.cache/" "/elpa/"))
   :config
   (recentf-mode 1))
 

--- a/lisp/core-prog.el
+++ b/lisp/core-prog.el
@@ -17,17 +17,15 @@
         (go    "https://github.com/tree-sitter/tree-sitter-go")
         (gomod "https://github.com/camdencheek/tree-sitter-go-mod")
         (rust  "https://github.com/tree-sitter/tree-sitter-rust")
-        (cmake "https://github.com/uyha/tree-sitter-cmake")
-        (toml  "https://github.com/tree-sitter/tree-sitter-toml")
-        (json  "https://github.com/tree-sitter/tree-sitter-json")
-        (yaml  "https://github.com/ikatyang/tree-sitter-yaml")))
+        (cmake "https://github.com/uyha/tree-sitter-cmake")))
 
 (defun my/treesit-install-active-grammars ()
   "Install tree-sitter grammars used out-of-the-box if missing.
 `gomod' is included because `go-mod-ts-mode' is on `auto-mode-alist'
-for go.mod files; without the grammar, opening one errors out."
+for go.mod files; without the grammar, opening one errors out.
+`cmake' is included for `cmake-ts-mode' (CMakeLists.txt / .cmake)."
   (interactive)
-  (dolist (lang '(c cpp go gomod rust))
+  (dolist (lang '(c cpp go gomod rust cmake))
     (unless (treesit-language-available-p lang)
       (message "Installing tree-sitter grammar: %s" lang)
       (treesit-install-language-grammar lang))))
@@ -49,8 +47,11 @@ for go.mod files; without the grammar, opening one errors out."
               ("C-c l f" . eglot-format)
               ("C-c l h" . eldoc))
   :init
+  ;; Emacs 30's Eglot replaced `eglot-events-buffer-size' with
+  ;; `eglot-events-buffer-config'; the old name is no longer bound,
+  ;; so setting it had no effect on the events buffer.
   (setq eglot-autoshutdown t
-        eglot-events-buffer-size 0
+        eglot-events-buffer-config '(:size 0 :format full)
         eglot-extend-to-xref t
         eglot-sync-connect 1))
 
@@ -63,8 +64,7 @@ for go.mod files; without the grammar, opening one errors out."
 ;;; ---- Format on save (async) ---------------------------------------------
 
 (use-package apheleia
-  :config
-  (apheleia-global-mode 1))
+  :hook (after-init . apheleia-global-mode))
 
 ;;; ---- Snippets ------------------------------------------------------------
 
@@ -84,11 +84,17 @@ for go.mod files; without the grammar, opening one errors out."
 ;;; ---- Debugger -----------------------------------------------------------
 
 (use-package dape
+  ;; Defer loading until `M-x dape' (or any other dape entry point)
+  ;; is called; only `dape' itself is autoloaded by the package, so
+  ;; breakpoint persistence is wired up in `:config' — it runs after
+  ;; the first `dape' invocation, which is also the only point where
+  ;; new breakpoints could exist to save.
+  :commands (dape)
   :init
   (setq dape-buffer-window-arrangement 'right)
   :config
-  (add-hook 'kill-emacs-hook #'dape-breakpoint-save)
-  (add-hook 'after-init-hook #'dape-breakpoint-load))
+  (dape-breakpoint-load)
+  (add-hook 'kill-emacs-hook #'dape-breakpoint-save))
 
 ;;; ---- Discoverability ----------------------------------------------------
 

--- a/lisp/core-project.el
+++ b/lisp/core-project.el
@@ -1,8 +1,7 @@
 ;;; core-project.el --- Project & VCS -*- lexical-binding: t; -*-
 
-(use-package project
-  :ensure nil
-  :bind-keymap ("C-x p" . project-prefix-map))
+;; `project' (built-in) already binds `C-x p' to `project-prefix-map'
+;; in Emacs 28+, so no explicit configuration is needed here.
 
 (use-package magit
   :bind (("C-x g"   . magit-status)
@@ -11,18 +10,38 @@
   (setq magit-diff-refine-hunk t))
 
 ;; macOS GUI Emacs doesn't inherit shell PATH; this fixes that.
+;;
+;; A login + interactive zsh costs 200-1000ms per startup. We cache
+;; the resolved env to a file and re-run only when any shell rc has
+;; been modified more recently than the cache. Touch any of those
+;; files (or delete the cache) to force a refresh.
 (use-package exec-path-from-shell
   :if (memq window-system '(mac ns x))
   :init
-  ;; Use a login + interactive shell so .zprofile AND .zshrc are both
-  ;; sourced — most user PATH additions on macOS live in .zshrc, which
-  ;; is never sourced under the (faster) non-interactive default.
   (setq exec-path-from-shell-arguments '("-l" "-i")
         exec-path-from-shell-variables
         '("PATH" "MANPATH" "GOPATH" "GOROOT"
           "CARGO_HOME" "RUSTUP_HOME"))
   :config
-  (exec-path-from-shell-initialize))
+  (let* ((cache (expand-file-name "exec-path-cache.el" user-emacs-directory))
+         (mtime (lambda (f)
+                  (and (file-exists-p f)
+                       (float-time (file-attribute-modification-time
+                                    (file-attributes f))))))
+         (rc-mtime (apply #'max 0
+                          (delq nil
+                                (mapcar (lambda (f) (funcall mtime (expand-file-name f)))
+                                        '("~/.zshenv" "~/.zprofile" "~/.zshrc")))))
+         (cache-mtime (or (funcall mtime cache) 0)))
+    (if (> cache-mtime rc-mtime)
+        (load cache 'noerror 'nomessage)
+      (exec-path-from-shell-initialize)
+      (with-temp-file cache
+        (insert ";;; -*- lexical-binding: t; no-byte-compile: t -*-\n")
+        (dolist (v exec-path-from-shell-variables)
+          (when-let ((val (getenv v)))
+            (insert (format "(setenv %S %S)\n" v val))))
+        (insert (format "(setq exec-path '%S)\n" exec-path))))))
 
 ;; direnv bridge: per-project env (loaded transparently from .envrc)
 (use-package envrc

--- a/lisp/core-ui.el
+++ b/lisp/core-ui.el
@@ -6,7 +6,7 @@
 
 (use-package display-line-numbers
   :ensure nil
-  :hook ((prog-mode org-mode markdown-mode gfm-mode) . display-line-numbers-mode)
+  :hook ((prog-mode org-mode markdown-mode) . display-line-numbers-mode)
   :init
   (setq display-line-numbers-type t
         display-line-numbers-width 4

--- a/lisp/core-ui.el
+++ b/lisp/core-ui.el
@@ -31,26 +31,12 @@
 (use-package rainbow-delimiters
   :hook (prog-mode . rainbow-delimiters-mode))
 
-;; Font management via cnfonts — the canonical solution for Chinese
-;; Emacs users. It picks per-size font pairs so 1 CJK glyph occupies
-;; exactly 2 ASCII columns, without manual rescale measurement.
-;;
-;; First run: `cnfonts-mode' applies a default profile. To pick a size
-;; interactively, use `M-x cnfonts-increase-fontsize' /
-;; `cnfonts-decrease-fontsize'; the choice persists in
-;; ~/.emacs.d/cnfonts/.
-(use-package cnfonts
-  :hook (after-init . cnfonts-mode)
-  :init
-  (setq cnfonts-default-fontsize 18
-        ;; Let the frame grow/shrink in pixels when cnfonts switches size,
-        ;; so the column/row count stays constant across profiles.
-        cnfonts-keep-frame-size nil
-        cnfonts-personal-fontnames
-        '(("JetBrains Mono" "Fira Code" "SF Mono" "Menlo")
-          ("Sarasa Mono SC" "PingFang SC" "Hiragino Sans GB" "STHeiti")
-          ("Sarasa Mono SC")
-          ("Sarasa Mono SC"))))
+;; Ubuntu Mono — installed under ~/Library/Fonts. CJK glyphs fall
+;; through to the system's Chinese font (PingFang SC etc.) via macOS'
+;; default fontset, so we don't wire CJK explicitly here.
+;; Org-table CJK alignment will need follow-up: PingFang isn't 1:2
+;; equal-width with Ubuntu Mono.
+(set-face-attribute 'default nil :family "Ubuntu Mono" :height 180)
 
 (setq window-divider-default-places t
       window-divider-default-bottom-width 1


### PR DESCRIPTION
## Summary
- Replace cnfonts with a direct \`set-face-attribute\` on Ubuntu Mono (height 180); CJK falls through macOS' default fontset
- Drop the cnfonts-only \`frame-inhibit-implied-resize\` setting in early-init.el
- Rebind \`set-mark-command\` from C-' to C-;
- README font/CJK sections updated alongside

## Test plan
- [ ] Restart Emacs; default face renders as Ubuntu Mono ~18pt
- [ ] \`C-;\` starts a region selection; old \`C-'\` no longer bound to set-mark
- [ ] Org / Markdown CJK content still readable (1:2 alignment caveat noted in README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)